### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@ Template of a custom package for [skiros2](https://github.com/RVMI/skiros2).
 ### Configure steps
 
 * Replace word "template" with your package name:
+```
 > cd skiros2_template_lib  
 > sed -i 's/template/my_pkg_name/' *.*  
-
+```
 * Replace word "xyz" with your robot name:
+```
 > sed -i 's/xyz/my_robot_name/' *.*
-
+```
 * Launch main.launch
+```
 > roslaunch skiros2_template_lib main.launch
-
+```
 


### PR DESCRIPTION
inserted the code block style for bash commands. otherwise the "*.*" are visualized by the MD interpreter as an italic "."